### PR TITLE
Nutteloze functie verwijderd

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -4,8 +4,7 @@
 add_theme_support( 'post-thumbnails' );
 set_post_thumbnail_size( 200, 96, true );
 
-/*Smooth scroll Top functie que*/
-wp_enqueue_script( 'smoothup', get_template_directory_uri() . '/js/smoothscroll.js', array( 'jquery' ), '',  true );
+
 
 
 /**


### PR DESCRIPTION
Fix voor: Notice: wp_enqueue_script werd verkeerd aangeroepen. Scripts
en styles zouden niet geregistreerd mogen worden of zouden niet uit de
wachtrij mogen verdwijnen tot de wp_enqueue_scripts,
admin_enqueue_scripts, of login_enqueue_scripts overeenkomen. Bezoek de
Debugging in WordPress-pagina voor meer informatie. (Dit bericht is
toegevoegd in versie 3.3.) in
H:\xampp\htdocs\dev-ongekunsteld\wp-includes\functions.php on line 3547
