### PR TITLE
Op pages geen indent

### DIFF
--- a/style.css
+++ b/style.css
@@ -46,7 +46,7 @@ strong {
 
 .page strong {
 		font-weight:600;
-		font-size:.9em;
+		font-size:1em;
 		text-indent:20px !important;
 }
 em {

--- a/style.css
+++ b/style.css
@@ -43,6 +43,12 @@ strong {
 	font-weight:600;
 	font-style:normal;
 }
+
+.page strong {
+		font-weight:600;
+		font-size:.9em;
+		text-indent:20px !important;
+}
 em {
 	font-weight:100;
 	font-style:italic;
@@ -466,6 +472,10 @@ nav {
 h2+p {
 	text-indent:0px !important;
 }
+
+.page .entry-content p {
+	text-indent:0px;
+	}
 .entry-content h2 {
 	padding-left:42px;
 	font-family:"lft-etica",sans-serif;


### PR DESCRIPTION
Op pages bestaat de hoefte aan meer overzicht en subkpjes. De <strong>
voor pages is aangepast om kopjes te kunnen maken, en de indent
verwijderd. Stuk overzichtelijker.
