### PR TITLE
Extra witruitme onder artikelen op de frontpage

### DIFF
--- a/style.css
+++ b/style.css
@@ -441,8 +441,11 @@ nav {
     font-weight: 200;
     letter-spacing: 0.1em;
     font-style: normal;
-
 }
+
+.entry-summary p {
+	margin-bottom:54px;
+	}
 .entry-content {
 	text-align:justify;
 	text-justify:inter-word;


### PR DESCRIPTION
De witruimte rond de leadtekst was niet overal gelijk, zijkanten breder
dan onder. Dat is nu gelijk.
